### PR TITLE
Remove initialization message

### DIFF
--- a/evil-magit.el
+++ b/evil-magit.el
@@ -577,8 +577,7 @@ go back to evil-magit behavior."
   (interactive)
   (evil-magit-adjust-section-bindings)
   (evil-magit-adjust-popups)
-  (evil-magit-set-initial-states)
-  (message "evil-magit initialized"))
+  (evil-magit-set-initial-states))
 (evil-magit-init)
 
 ;;;###autoload


### PR DESCRIPTION
Hi, and thanks for this package!

This PR removes a message printed by evil-magit on initialization. Maybe the message is useful for people, but for me it's kind of a distraction - I primarily expect to see errors in the echo area, "evil-magit initialized" triggers a false alarm in me each time I see it.

