### PR TITLE
Remove magit-popup as a dependency

### DIFF
--- a/evil-magit.el
+++ b/evil-magit.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2015-2016 Justin Burkett
 
 ;; Author: Justin Burkett <justin@burkett.cc>
-;; Package-Requires: ((evil "1.2.3") (magit "2.6.0") (magit-popup "2.12.5"))
+;; Package-Requires: ((evil "1.2.3") (magit "2.6.0"))
 ;; Homepage: https://github.com/justbur/evil-magit
 ;; Version: 0.4.1
 


### PR DESCRIPTION
I believe the dependency is not needed after the current changes